### PR TITLE
Fix when a or b might be null (e.g. Async items)

### DIFF
--- a/src/ngx-order.pipe.ts
+++ b/src/ngx-order.pipe.ts
@@ -43,8 +43,12 @@ export class OrderPipe implements PipeTransform {
         return a > b ? 1 : -1;
       }
 
-      if (!isDeepLink) {
-        return a[expression] > b[expression] ? 1 : -1;
+      if (!isDeepLink && expression) {
+          if (a && b) {
+              return a[expression] > b[expression] ? 1 : -1;
+          } else {
+              return a > b ? 1 : -1;
+          }
       }
 
       return OrderPipe.getValue(a, expression) > OrderPipe.getValue(b, expression) ? 1 : -1;


### PR DESCRIPTION
Fixes `Cannot read property foo of null` error. For example, below code might cause error:

`<ion-item-sliding *ngFor="let item of items | async | orderBy: 'isDone' : false; let i = index;">
        <ion-item>{{item.text}}</ion-item>
</ion-item-sliding>`

With fix proposed in pull request, no errors occur during application run.