### PR TITLE
multiple fields sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In case you're using `systemjs` - see configuration [here](https://github.com/Va
 | Param | Type | Default | Details |
 | --- | --- | --- | --- |
 | collection | `array` or `object` | | The collection or object to sort |
-| expression  | `string` | | The key to determinate order |
+| expression  | `string array` or `string` | | The collection of keys or key to determinate order |
 | reverse *(optional)* | `boolean`| false | Reverse sorting order |
 | caseInsensitive *(optional)* | `boolean`| false | Case insensitive compare for sorting |
 | comparator *(optional)* | `Function`|  | Custom comparator function to determine order of value pairs. Example: `(a, b) => { return a > b ? 1 : -1; }` [`See how to use comparator`](https://github.com/VadimDez/ngx-order-pipe/issues/39) |

--- a/src/app/order-pipe/ngx-order.pipe.spec.ts
+++ b/src/app/order-pipe/ngx-order.pipe.spec.ts
@@ -290,19 +290,19 @@ describe('OrderPipe', () => {
     });
   });
 
-  // it('should sort by multiple fields', () => {
-  //   const array = [
-  //     { name: 'qwe', age: 1 },
-  //     { name: 'asd', age: 3 },
-  //     { name: 'asd', age: 2 },
-  //   ];
-  //
-  //   const result = [
-  //     { name: 'asd', age: 2 },
-  //     { name: 'asd', age: 3 },
-  //     { name: 'qwe', age: 1 },
-  //   ];
-  //
-  //   expect(pipe.transform(array, 'name,age')).toEqual(result);
-  // });
+  it('should sort by multiple fields', () => {
+    const array = [
+      { name: 'qwe', age: 1 },
+      { name: 'asd', age: 3 },
+      { name: 'asd', age: 2 },
+    ];
+  
+    const result = [
+      { name: 'asd', age: 2 },
+      { name: 'asd', age: 3 },
+      { name: 'qwe', age: 1 },
+    ];
+    
+    expect(pipe.transform(array, ['name','age'])).toEqual(result);
+  });
 });

--- a/src/app/order-pipe/ngx-order.pipe.ts
+++ b/src/app/order-pipe/ngx-order.pipe.ts
@@ -97,6 +97,17 @@ export class OrderPipe implements PipeTransform {
     if (!value) {
       return value;
     }
+
+    if(Array.isArray(expression)) {
+      const expressions = <any[]>expression;
+      let transformResult = value;
+
+      expressions.reverse().forEach(splittedExpression => {
+        transformResult = this.transform(transformResult, splittedExpression, reverse, isCaseInsensitive, comparator);
+      });
+
+      return transformResult;
+    }
     
     if (Array.isArray(value)) {
       return this.sortArray(value.slice(), expression, reverse, isCaseInsensitive, comparator);


### PR DESCRIPTION
Hi VadimDez,

Something that was missing to me was the ability of sorting per multiple expressions; clearly piping multiple instances of orderby could have done the trick here but the user should then take into account that he/she has to reverse the order of the orderby piping.

I have see that you had already made a test with multiple expressions already and I think the array way of dealing with expressions make more sense than a joined string using ',' as a delemiter.

Hope it doesn't go too much against the flow