### PR TITLE
Remove .reverse from multiExpressionTransform

### DIFF
--- a/src/app/order-pipe/ngx-order.pipe.ts
+++ b/src/app/order-pipe/ngx-order.pipe.ts
@@ -210,7 +210,7 @@ export class OrderPipe implements PipeTransform {
    * @returns {any}
    */
   private multiExpressionTransform(value: any, expressions: any[], reverse: boolean, isCaseInsensitive: boolean = false, comparator?: Function): any {
-    return expressions.reverse().reduce((result: any, expression: any) => {
+    return expressions.reduce((result: any, expression: any) => {
       return this.transform(result, expression, reverse, isCaseInsensitive, comparator);
     }, value);
   }


### PR DESCRIPTION
When using multiple sort keys with a pipe in a `*ngFor` like `['sortKeyA', 'sortKeyB']`, I was seeing a flickering in my HTML view because the sort key order was constantly changing. I identified this was because of the `expression.reverse()` in `multiExpressionTransform`. 

`array.reverse()` reverses the array in place. Which means on the next angular check cycle the array is different and then reversed again. Removing the `expression.reverse()` stops this, removing repeated sorting changing happening in components.

Perhaps the `reverse` was required? But I can't see a reason for it to be run on every process cycle.

References:
[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse]()
