### PR TITLE
fix error when expression point on sub-property of an undefined object

### DIFF
--- a/src/app/order-pipe/ngx-order.pipe.ts
+++ b/src/app/order-pipe/ngx-order.pipe.ts
@@ -67,6 +67,9 @@ export class OrderPipe implements PipeTransform {
    */
   static getValue(object: any, expression: string[]) {
     for (let i = 0, n = expression.length; i < n; ++i) {
+      if( !object ){
+        return;
+      }
       const k = expression[i];
       if (!(k in object)) {
         return;


### PR DESCRIPTION
avoid error "Cannot use 'in' operator to search for 'property' in undefined"

test case :
```ts
const list = [{a:{b:1}},   {a:{b:2}},   {a:undefined}];
```
```html
<div *ngFor="let item of list | orderBy:'a.b'">
</div>
```