### PR TITLE
Fix error ordering by null date propertie

### DIFF
--- a/src/app/order-pipe/ngx-order.pipe.spec.ts
+++ b/src/app/order-pipe/ngx-order.pipe.spec.ts
@@ -441,6 +441,20 @@ describe("OrderPipe", () => {
       );
     });
 
+    it("should sort dates also including null as date", () => {
+      const a = { date: new Date(1980, 11, 31, 0, 0, 0, 0) };
+      const b = { date: null };
+      const c = { date: new Date(1978, 10, 12, 0, 0, 0, 0) };
+
+      const collection = [a, b, c];
+      const result = [c, a, b];
+
+      expect(pipe.transform(collection, "date")).toEqual(result);
+      expect(pipe.transform(collection, "date", true)).toEqual(
+        result.reverse()
+      );
+    });
+
     describe("multisort with dates", () => {
       it("should sort dates equal dates", () => {
         const a = {

--- a/src/app/order-pipe/ngx-order.pipe.ts
+++ b/src/app/order-pipe/ngx-order.pipe.ts
@@ -2,7 +2,7 @@ import { Pipe, PipeTransform } from "@angular/core";
 
 @Pipe({
   name: "orderBy",
-  pure: false
+  pure: false,
 })
 export class OrderPipe implements PipeTransform {
   /**
@@ -35,9 +35,12 @@ export class OrderPipe implements PipeTransform {
    */
   static defaultCompare(a: any, b: any) {
     if (a && a instanceof Date) {
-        a = a.getTime();
-        b = b.getTime();
+      a = a.getTime();
     }
+    if (b && b instanceof Date) {
+      b = b.getTime();
+    }
+
     if (a === b) {
       return 0;
     }

--- a/src/app/order-pipe/ngx-order.pipe.ts
+++ b/src/app/order-pipe/ngx-order.pipe.ts
@@ -34,7 +34,7 @@ export class OrderPipe implements PipeTransform {
    * @param b
    */
   static defaultCompare(a: any, b: any) {
-    if (a instanceof Date) {
+    if (a && a instanceof Date) {
         a = a.getTime();
         b = b.getTime();
     }


### PR DESCRIPTION
Fix: If the property is Date and it is null, it throws the following error: "ERROR TypeError: Cannot read property 'getTime' of null"