### PR TITLE
Make sure ES5 target is supported fixes #110

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -15,4 +15,4 @@ last 2 Safari major versions
 last 2 iOS major versions
 Firefox ESR
 not IE 9-10 # Angular support for IE 9-10 has been deprecated and will be removed as of Angular v11. To opt-in, remove the 'not' prefix on this line.
-not IE 11 # Angular supports IE 11 only as an opt-in. To opt-in, remove the 'not' prefix on this line.
+IE 11 # Angular supports IE 11 only as an opt-in. To opt-in, remove the 'not' prefix on this line.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,8 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
-    "module": "es2020",
-    "lib": ["es2018", "dom"]
+    "target": "es5",
+    "module": "esnext",
+    "lib": ["es2017", "dom"]
   }
 }


### PR DESCRIPTION
To support older browsers (like IE11) the target is reduced to ES5 so all code is also transpiled to that target.