### PR TITLE
Fix expression array being reversed

### DIFF
--- a/src/app/order-pipe/ngx-order.pipe.ts
+++ b/src/app/order-pipe/ngx-order.pipe.ts
@@ -120,7 +120,7 @@ export class OrderPipe implements PipeTransform {
     if (Array.isArray(expression)) {
       return this.multiExpressionTransform(
         value,
-        expression,
+        expression.slice(),
         reverse,
         isCaseInsensitive,
         comparator


### PR DESCRIPTION
When used with an array of expressions, the order pipe calls .reverse on it which will modify the given array and affect the next pipe call.

exemple usage which fails : `| orderBy: ['a', 'b']"` each time angular will re-render the dom the array will be reverse()'d and the display order will change