### PR TITLE
Build with ivy parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:ci": "ng test --watch=false --browsers=ChromeHeadlessCustom",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "packagr": "ng-packagr -p package.json",
+    "packagr": "ng-packagr -p package.json -c tsconfig.json",
     "docs": "ng build --prod --output-path docs --base-href ngx-order-pipe && cp ./docs/index.html ./docs/404.html"
   },
   "repository": {


### PR DESCRIPTION
Change ng-packagr to build with project's `tsconfig.json`. The result is it builds with ivy only. 

This PR is a following after this issue #154